### PR TITLE
feat(#4): add full CRUD endpoints for counters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@types/express": "^5.0.0",
         "argon2": "^0.44.0",
         "dotenv": "^17.2.3",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "groq-sdk": "^0.36.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -181,6 +182,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/pg": {
       "version": "8.15.6",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
@@ -234,6 +245,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -273,6 +296,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -300,6 +335,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -362,6 +403,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/content-disposition": {
@@ -445,6 +498,15 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -547,6 +609,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -560,6 +637,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -624,6 +710,41 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/forwarded": {
@@ -702,11 +823,56 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/groq-sdk": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-0.36.0.tgz",
+      "integrity": "sha512-wvxl7i6QWxLcIfM00mQQybYk15OAXJG0NBBQuMDHrQ2vi68uz2RqFTBKUNfEOVz8Lwy4eAgQIPBEFW5P3cXybA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/groq-sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/groq-sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -740,6 +906,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -873,6 +1048,46 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-gyp-build": {
@@ -1253,6 +1468,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -1362,6 +1583,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@types/express": "^5.0.0",
     "argon2": "^0.44.0",
     "dotenv": "^17.2.3",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "groq-sdk": "^0.36.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/common/counter.ts
+++ b/src/common/counter.ts
@@ -1,0 +1,5 @@
+export type Counter = {
+  id: string;
+  name: string;
+  value: number;
+};

--- a/src/database.ts
+++ b/src/database.ts
@@ -5,7 +5,7 @@ import dotenv from "dotenv";
 // Load environment variables from .env.development.local for local development.
 dotenv.config({ path: ".env.development.local" });
 
-const sql = neon(process.env.COUNT_ANYTHING_DB_DATABASE_URL);
+export const sql = neon(process.env.COUNT_ANYTHING_DB_DATABASE_URL);
 
 export async function dbVersion() {
   const [row] = await sql`SELECT version()`;
@@ -23,15 +23,15 @@ export async function insertAccount(email: string, passwordHash: string) {
       INSERT INTO accounts (email)
       VALUES (${email})
       RETURNING id`;
-  
+
     const accountId = accountResult.id;
-  
+
     await sql`
       INSERT INTO passwords (accountid, hashedvalue)
       VALUES (${accountId}, ${passwordHash})`;
-  
+
     return accountId;
-  }
+  };
 
   return createTransaction(sqlFunction);
 }

--- a/src/endpoints/counters/createCounter.ts
+++ b/src/endpoints/counters/createCounter.ts
@@ -1,0 +1,23 @@
+import type { Request, Response } from "express";
+import type { Counter } from "../../common/counter.js";
+import { sql } from "../../database.js";
+
+export async function createCounter(req: Request, res: Response) {
+  const { name } = req.body;
+
+  if (!name) {
+    return res.status(400).json({ error: "Name is required" });
+  }
+
+  try {
+    const [counter] = (await sql`
+      INSERT INTO counters (name, value) 
+      VALUES (${name},0)
+      RETURNING id, name, value 
+    `) as Counter[];
+
+    res.status(201).json(counter);
+  } catch (error) {
+    res.status(500).json({ error: "Server error" });
+  }
+}

--- a/src/endpoints/counters/decrementCounter.ts
+++ b/src/endpoints/counters/decrementCounter.ts
@@ -1,0 +1,26 @@
+import type { Request, Response } from "express";
+import type { Counter } from "../../common/counter.js";
+import { sql } from "../../database.js";
+
+export async function decrementCounter(req: Request, res: Response) {
+  const { id } = req.params;
+
+  try {
+    const [updatedCounter] = (await sql`
+      UPDATE counters
+      SET value = GREATEST(value - 1, 0)
+      WHERE id = ${id}
+      RETURNING *
+    `) as Counter[];
+
+    if (!updatedCounter) {
+      res.status(404).json({ error: `Counter with id: ${id} not found` });
+    }
+
+    return res.json(updatedCounter);
+  } catch (error) {
+    res
+      .status(500)
+      .json({ error: `Could not decrement counter with id: ${id}` });
+  }
+}

--- a/src/endpoints/counters/deleteCounter.ts
+++ b/src/endpoints/counters/deleteCounter.ts
@@ -1,0 +1,25 @@
+import type { Request, Response } from "express";
+import type { Counter } from "../../common/counter.js";
+import { sql } from "../../database.js";
+
+type CounterId = Pick<Counter, "id">;
+
+export async function deleteCounter(req: Request, res: Response) {
+  const { id } = req.params;
+
+  try {
+    const deletedId = (await sql`
+      DELETE FROM counters
+      WHERE id = ${id}
+      RETURNING id
+  `) as CounterId[];
+
+    if (!deletedId) {
+      res.status(404).json({ error: `Counter with id: ${id} not found` });
+    }
+
+    return res.json(deletedId);
+  } catch (error) {
+    res.status(500).json({ error: `Could not delete counter with id: ${id}` });
+  }
+}

--- a/src/endpoints/counters/getCounters.ts
+++ b/src/endpoints/counters/getCounters.ts
@@ -1,0 +1,22 @@
+import type { Request, Response } from "express";
+import type { Counter } from "../../common/counter.js";
+import { sql } from "../../database.js";
+
+export async function getCounters(req: Request, res: Response) {
+  try {
+    const counters = (await sql`
+    SELECT * FROM counters 
+    ORDER BY id ASC`) as Counter[];
+
+    if (counters.length === 0) {
+      return res.status(404).json({ error: "No counters found" });
+    }
+
+    return res.json(counters);
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(500)
+      .json({ error: "Error fetching counters from server" });
+  }
+}

--- a/src/endpoints/counters/incrementCounter.ts
+++ b/src/endpoints/counters/incrementCounter.ts
@@ -1,0 +1,26 @@
+import type { Request, Response } from "express";
+import type { Counter } from "../../common/counter.js";
+import { sql } from "../../database.js";
+
+export async function incrementCounter(req: Request, res: Response) {
+  const { id } = req.params;
+
+  try {
+    const [updatedCounter] = (await sql`
+      UPDATE counters
+      SET value = value + 1
+      WHERE id = ${id}
+      RETURNING *
+    `) as Counter[];
+
+    if (!updatedCounter) {
+      res.status(404).json({ error: `Counter with id: ${id}  not found` });
+    }
+
+    return res.json(updatedCounter);
+  } catch (error) {
+    res
+      .status(500)
+      .json({ error: `Could not increment counter with id: ${id}` });
+  }
+}

--- a/src/endpoints/counters/resetCounter.ts
+++ b/src/endpoints/counters/resetCounter.ts
@@ -1,0 +1,24 @@
+import type { Request, Response } from "express";
+import type { Counter } from "../../common/counter.js";
+import { sql } from "../../database.js";
+
+export async function resetCounter(req: Request, res: Response) {
+  const { id } = req.params;
+
+  try {
+    const resetedCounter = (await sql`
+      UPDATE counters
+      SET value = 0
+      WHERE id = ${id}
+      RETURNING *
+      `) as Counter[];
+
+    if (!resetedCounter) {
+      res.status(404).json({ error: `Counter with id: ${id} not found` });
+    }
+
+    return res.json(resetedCounter);
+  } catch (error) {
+    res.status(500).json({ error: `Could not reset counter with id: ${id}` });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import express from "express";
 import { dbTime, dbVersion } from "./database.js";
 import { registerAccount } from "./endpoints/registerAccount.js";
+import { getCounters } from "./endpoints/counters/getCounters.js";
+import { createCounter } from "./endpoints/counters/createCounter.js";
+import { incrementCounter } from "./endpoints/counters/incrementCounter.js";
+import { decrementCounter } from "./endpoints/counters/decrementCounter.js";
+import { deleteCounter } from "./endpoints/counters/deleteCounter.js";
+import { resetCounter } from "./endpoints/counters/resetCounter.js";
 
 const app = express();
 app.use(express.json());
@@ -30,6 +36,13 @@ if (process.env.VERCEL !== "1") {
     console.log(`\nRunning at http://localhost:${PORT}\n`)
   );
 }
+
+app.get("/counters", getCounters);
+app.post("/counters", createCounter);
+app.post("/counters/:id/increment", incrementCounter);
+app.post("/counters/:id/decrement", decrementCounter);
+app.post("/counters/:id/reset", resetCounter);
+app.delete("/counters/:id/delete", deleteCounter);
 
 app.get("/test", (req, res) => {
   res.send("test");


### PR DESCRIPTION
- Added `counter.ts` type definition
- Implemented 6 endpoints in `endpoints/counters`:
  - `createCounter`
  - `getCounters`
  - `incrementCounter`
  - `decrementCounter`
  - `resetCounter`
  - `deleteCounter`
- Updated `index.ts` to include counter routes
- All endpoints use SQL queries via `sql` from `database.js`